### PR TITLE
If file exists, use 'Reveal' instead of 'Open Dir'

### DIFF
--- a/src/aria_actions.py
+++ b/src/aria_actions.py
@@ -34,7 +34,11 @@ def get_task_name(gid):
 
 def open_dir(gid):
     dir = server.tellStatus(gid, ['dir'])['dir']
-    os_command = 'open ' + dir
+    filepath = dir + get_task_name(gid)
+    if os.path.exists(filepath):
+        os_command = 'open -R "%s"' % filepath
+    else:
+        os_command = 'open "%s" ' % dir
     os.system(os_command)
 
 


### PR DESCRIPTION
If file exists, press "Enter" button to reveal the file in Finder instead of just open the directory.
Also wrap the directory path in quotation marks in case there is space in it.

如果文件存在，按 Enter 键后打开文件所在目录并选中（Reveal）。
另外，将地址用引号括起来，以防地址中有空格。
