### PR TITLE
Fixed the method to get filepath

### DIFF
--- a/src/aria.py
+++ b/src/aria.py
@@ -247,8 +247,7 @@ def get_completed_tasks(command, filter):
         info = '100%, File Size: {size}'.format(size=size_fmt(size))
         arg = '--' + command + ' ' + task['gid']
         subs = get_modifier_subs(done=True, info=info)
-        filepath = os.path.join(server.tellStatus(secret, task['gid'], ['dir'])['dir'],
-                                get_task_name(task).encode('utf-8'))
+        filepath = server.getFiles(secret, task['gid'])[0]['path']
         if not os.path.exists(filepath):
             info = '[deleted] ' + info
             wf.add_item(name, info, arg=arg, valid=True, 

--- a/src/aria_actions.py
+++ b/src/aria_actions.py
@@ -35,7 +35,7 @@ def get_task_name(gid):
 
 def reveal(gid):
     dir = server.tellStatus(secret, gid, ['dir'])['dir']
-    filepath = os.path.join(dir, get_task_name(gid).encode('utf-8'))
+    filepath = server.getFiles(secret, gid)[0]['path'].encode('utf-8')
     if os.path.exists(filepath):
         os_command = 'open -R "%s"' % filepath
     else:


### PR DESCRIPTION
对于部分迅雷离线创建的下载任务（在迅雷离线中种子文件点打开，然后单独下载里面的文件），aria2 会自动生成文件夹，但原有的方法没能获取完整的路径。

![napkin 04-12-16 1 49 24 pm](https://cloud.githubusercontent.com/assets/3814129/14450958/6dee4746-00b5-11e6-9990-85c1aa5ffb37.jpeg)
